### PR TITLE
feat: add material search interface

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/file-saver@2.0.5/dist/FileSaver.min.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Поиск материалов/i);
+  expect(header).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,107 @@
-import React from 'react';
-import logo from './logo.svg';
+import React, { useState } from 'react';
 import './App.css';
 
+interface Item {
+  name: string;
+  article: string;
+  manufacturer: string;
+  link: string;
+}
+
 function App() {
+  const [items, setItems] = useState<Item[]>([]);
+  const [manufacturers, setManufacturers] = useState<string[]>(['ABB', 'Schneider', 'Legrand']);
+  const [newManufacturer, setNewManufacturer] = useState('');
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      const data = new Uint8Array(evt.target?.result as ArrayBuffer);
+      const workbook = (window as any).XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows: any[][] = (window as any).XLSX.utils.sheet_to_json(sheet, { header: 1 });
+      const parsed: Item[] = rows.map((row) => {
+        const name = row[0] ? String(row[0]) : '';
+        const manufacturer =
+          manufacturers.find((m) => name.toLowerCase().includes(m.toLowerCase())) || '';
+        const article = extractArticle(name);
+        const query = `${article || name} ${manufacturer}`.trim();
+        const link = `https://www.etm.ru/catalog/?q=${encodeURIComponent(query)}`;
+        return { name, article, manufacturer, link };
+      });
+      setItems(parsed);
+    };
+    reader.readAsArrayBuffer(file);
+  };
+
+  const extractArticle = (text: string): string => {
+    const match = text.match(/[A-Za-z0-9-]+/);
+    return match ? match[0] : '';
+  };
+
+  const addManufacturer = () => {
+    if (newManufacturer.trim()) {
+      setManufacturers([...manufacturers, newManufacturer.trim()]);
+      setNewManufacturer('');
+    }
+  };
+
+  const exportExcel = () => {
+    const XLSX = (window as any).XLSX;
+    const ws = XLSX.utils.json_to_sheet(items);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Results');
+    const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+    (window as any).saveAs(
+      new Blob([wbout], { type: 'application/octet-stream' }),
+      'results.xlsx'
+    );
+  };
+
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <h1>Поиск материалов</h1>
+      <div>
+        <input type="file" accept=".xlsx,.xls" onChange={handleFile} />
+      </div>
+      <div>
+        <input
+          value={newManufacturer}
+          onChange={(e) => setNewManufacturer(e.target.value)}
+          placeholder="Добавить производителя"
+        />
+        <button onClick={addManufacturer}>Добавить</button>
+      </div>
+      {items.length > 0 && <button onClick={exportExcel}>Экспорт в Excel</button>}
+      <table>
+        <thead>
+          <tr>
+            <th>Наименование</th>
+            <th>Артикул</th>
+            <th>Производитель</th>
+            <th>Ссылка</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, idx) => (
+            <tr key={idx}>
+              <td>{item.name}</td>
+              <td>{item.article}</td>
+              <td>{item.manufacturer}</td>
+              <td>
+                <a href={item.link} target="_blank" rel="noreferrer">
+                  ETM
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
 export default App;
+


### PR DESCRIPTION
## Summary
- enable client-side Excel parsing with CDN scripts
- add React page to upload material list, manage manufacturers, and export results
- update tests for new interface

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_689c880508d0832ab1a8a62cbb15ba95